### PR TITLE
docs: clarify font-size initial comment

### DIFF
--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -12,7 +12,7 @@ $fa-font-path: "../fonts/font-awesome" !default;
 /*
  * Typography
  * ======================================================================== */
-$font-size-initial: 14px; // reset default browser value from 16px to 13px
+$font-size-initial: 14px; // reset default browser value from 16px to 14px
 $font-size-base: 1rem !default;
 $font-size-lg: 1.25rem !default;
 $font-size-sm: 0.875rem !default;


### PR DESCRIPTION
## Summary
- clarify typography variable comment about default font size

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689549810de08322af7643119baa20e1