### PR TITLE
Fix close button text condition in Widget component

### DIFF
--- a/src/components/Widget/Widget.vue
+++ b/src/components/Widget/Widget.vue
@@ -62,7 +62,7 @@
         </a>
       </span>
       <a v-if="close" href="#" @click="closeWidget($event)" :id="`closeId-${randomId}`">
-        <strong v-if="typeof refresh === 'string'" class="text-gray-light">{{close}}</strong>
+        <strong v-if="typeof close === 'string'" class="text-gray-light">{{close}}</strong>
         <i v-else class="la la-remove"></i>
         <b-tooltip
           v-if="showTooltip"


### PR DESCRIPTION
## Summary
- fix close button conditional to depend on `close` prop

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895497d9b448322a4eca05401fe3496