### PR TITLE
fix header navigation spelling

### DIFF
--- a/src/components/Header/Header.vue
+++ b/src/components/Header/Header.vue
@@ -10,7 +10,7 @@
           <a href="/" class="menu"> About me</a>
         </b-nav-item>
         <b-nav-item>
-          <a href="/" class="menu"> Proyects</a>
+          <a href="/" class="menu"> Projects</a>
         </b-nav-item>
         <b-nav-item>
           <a href="/" class="menu"> Extra</a>


### PR DESCRIPTION
## Summary
- fix typo 'Proyects' to 'Projects' in header navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895497810048322b7d0131ea68b85a4