### PR TITLE
Fix sidebar static setting persistence

### DIFF
--- a/src/components/Layout/Layout.vue
+++ b/src/components/Layout/Layout.vue
@@ -49,8 +49,10 @@ export default {
   created() {
     const staticSidebar = JSON.parse(localStorage.getItem('sidebarStatic'));
 
-    if (staticSidebar) {
-      this.$store.state.layout.sidebarStatic = true;
+    if (staticSidebar !== null) {
+      // Persist the exact stored value instead of forcing `true`
+      // so that a saved `false` correctly disables the static sidebar.
+      this.$store.state.layout.sidebarStatic = staticSidebar;
     } else if (!this.sidebarClose) {
       setTimeout(() => {
         this.switchSidebar(true);


### PR DESCRIPTION
## Summary
- honor saved sidebarStatic value from localStorage instead of forcing true

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895459f1480832288409bb26d2c67a5